### PR TITLE
Fix incorrect playback speed (mono files) on some android devices

### DIFF
--- a/audiobook/src/main/java/de/ph1b/audiobook/mediaplayer/CustomMediaPlayer.java
+++ b/audiobook/src/main/java/de/ph1b/audiobook/mediaplayer/CustomMediaPlayer.java
@@ -56,6 +56,7 @@ public class CustomMediaPlayer implements MediaPlayerInterface {
     private volatile State state = State.IDLE;
     private MediaPlayer.OnErrorListener onErrorListener;
     private long duration;
+    private int channelCount;
 
 
     public CustomMediaPlayer() {
@@ -280,7 +281,7 @@ public class CustomMediaPlayer implements MediaPlayerInterface {
                 error("initStream", state);
                 throw new IOException("No KEY_CHANNEL_COUNT");
             }
-            int channelCount = oFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
+            channelCount = oFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
 
             if (!oFormat.containsKey(MediaFormat.KEY_MIME)) {
                 error("initStream", state);
@@ -432,9 +433,11 @@ public class CustomMediaPlayer implements MediaPlayerInterface {
                                 track.release();
                                 final MediaFormat oFormat = codec
                                         .getOutputFormat();
+
+                                // workaround - get channel count from media extractor, not from codec, because of speed bug with some devices
                                 initDevice(
                                         oFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
-                                        oFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT));
+                                        channelCount);
                                 outputBuffers = codec.getOutputBuffers();
                                 track.play();
                             } finally {


### PR DESCRIPTION
Hello, Paul. 
Today i can't use player at all, most of my books are in mono.
I decided to send patch that fixes incorrect speed playback. You can rewrite it as you wish.
It's a safe way. I dont think audio file can contain dynamic count of channels.

Also you can get almost correct channels count from AudioTrack instance without the need of another one variable, but when i tested it against files with more than 2 channels - i got crashes. Function findFormatFromChannels works only with two variants (1 and 2 channels), and returns incorrect -1 in other cases (which cause crash).

You can also make additional option in settings, that turns on this way of channels handling.

Also check this link, it might be helpful (not sure) http://code.google.com/p/chromium/issues/detail?id=256851

Thank you.

Harry

