### PR TITLE
BookPlayFragment: invalidate options menu onStart

### DIFF
--- a/audiobook/src/main/java/de/ph1b/audiobook/fragment/BookPlayFragment.java
+++ b/audiobook/src/main/java/de/ph1b/audiobook/fragment/BookPlayFragment.java
@@ -365,6 +365,8 @@ public class BookPlayFragment extends Fragment implements View.OnClickListener, 
         if (book != null)
             onBookContentChanged(book);
 
+        getActivity().invalidateOptionsMenu();
+
         communication.addOnBookContentChangedListener(this);
         communication.addOnPlayStateChangedListener(this);
         communication.addOnSleepStateChangedListener(this);


### PR DESCRIPTION
Previously:
* set sleep timer on book playback screen 
* lock screen without leaving book playback
* wait for sleep timer to fire
* unlock screen
* the sleep timer icon indicated that the timer was still running

The best solution I could find was to invalidate the options menu in BookPlayFragment.onStart(), which is fired after the screen is unlocked.